### PR TITLE
Improves bmp -> gdt encoding

### DIFF
--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -33,17 +33,18 @@ namespace CompileTools
         public override void ConvertTo(Stream input, Stream output)
         {
 
-            // Things handled correctly:
-            // GAMEOVER.GDT (scanlined)
-            // big-text portion of TITLE1.GDT (scanlined)
-            // text from EVO chapter 1 title screen, non-scanlined
-            // above, with blocks of all colors, pure and plane versions
+            // Input handled correctly:
+            // GAMEOVER.GDT
+            // MAP100.GDT (and likely other maps as well, but not tested)
+            // all title cards when cropped (remove bottom and right sides; they're only black anyway)
+            // EVO (SNES) chapter title 1
+            // above images with 16-bit color blocks pasted haphazardly
 
-            // Things not handled correctly:
-            // small-text portion of TITLE1.GDT (scanlined)
-            // game title screen (scanlined) (outputs 1kb file??)
-            //  - header is written correcctly, but no data...
-            // TITLE1.GDT full, scanlined and otherwise
+            // Inputs handled incorrectly:
+            // unedited title card images - smearing occurs
+            // game title screen (AV04B.GDT) - smearing occurs
+            // EVO chapter 1 title screen, doubled in size (but still 640x400 px) - smearing occurs
+            // 50% of scanlined images become blank if it's misaligned (you can shift the image up/down to fix this)
 
             Bitmap bmp = new Bitmap(Bitmap.FromStream(input));
             WriteInt16(output, unchecked((short)0xE488));
@@ -238,6 +239,13 @@ namespace CompileTools
                         }
                     }
                 }
+            }
+
+            if (output.Length == 11)
+            {
+                // It's probably misreading a scanliend image.
+                Console.WriteLine("Warning: Looks like the output image is blank.");
+                Console.WriteLine("If the input image has scanlines, try shifting it up or down a line.");
             }
         }
 

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -65,7 +65,10 @@ namespace CompileTools
                     prevPlaneData.Clear();
                     continue;
                 }
-                
+
+                List<List<int>> planes = new List<List<int>>();
+                // TODO: Store planes. Use comparative or to see whether positional encoding might be more efficient.
+
 
                 for (int plane = 0; plane < 3; plane++)                               // for each plane (B R G):
                 {

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -96,45 +96,43 @@ namespace CompileTools
                             }
                         }
 
-                        if (data > 0)
-                        {
-                            planeData.Add((byte)(height/2));
-                            Console.WriteLine(height / 2);
-                            planeData.Add((byte)data);
-                        }
+                        //if (data > 0)
+                        //{
+                        //    planeData.Add((byte)(height/2));
+                        //    Console.WriteLine(height / 2);
+                        //    planeData.Add((byte)data);
+                        //}
 
                         //if (data == runLengthData)
                         //{
-                         //   runLength++;
+                        //    runLength++;
                         //}
                         //else
                         //{
-
+                        //
                         //    planeData.Add((byte)runLengthData);
                         //    planeData.Add((byte)runLength);
-
-                         //   runLengthData = data;
+                        //
+                        //    runLengthData = data;
                         //    runLength = 1;
                         //}
 
-                        //planeData.Add(data);
+                        planeData.Add(data);
 
                         // If higher nibble equals lower nibble, add a 0x01.
                         // (Because the run length of each one is 0x01??? Why not just increment runlength?)
-                        //if (data >> 4 == (data & 0xF))
-                        //{
-                        //    planeData.Add(0x01);
-                        //}
+                        if (data >> 4 == (data & 0xF))
+                        {
+                            planeData.Add(0x01);
+                        }
                     }
                     //if (runLength > 1)
                     //{
                     //    planeData.Add((byte)runLengthData);
                     //    planeData.Add((byte)runLength);
-                   // }
+                    // }
 
-                    //output.WriteByte(0x04);
-
-                    if (planeData == prevPlaneData)
+                    if (planeData.SequenceEqual(prevPlaneData))
                     {
                         Console.WriteLine("they're the same!");
                         output.WriteByte(0x10);
@@ -142,15 +140,17 @@ namespace CompileTools
                     else
                     {
                         // 0x81 = begin POS
-                        output.WriteByte(0x81);
+                        //output.WriteByte(0x81);
+
+                        //0x04 = begin RLE
+                        output.WriteByte(0x04);
                         foreach (int d in planeData)
                         {
-                            // Next step: check if planeData is the same thing as the previous plane.
                             output.WriteByte((byte)d);
                         }
                         // 0xFF 0xFF = end POS
-                        output.WriteByte(0xFF);
-                        output.WriteByte(0xFF);
+                        //output.WriteByte(0xFF);
+                        //output.WriteByte(0xFF);
                     }
                     prevPlaneData = planeData;
                 }

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -89,19 +89,8 @@ namespace CompileTools
                         for (int dw = 0; dw < 8; dw++)                                // dw = difference in width; column in the block
 
                         {
-                            // TODO: Looks like the planes are not just BRG, but comething like cyan-orange-lime...
-                            //Console.WriteLine(((bmp.GetPixel(width + dw, height).ToArgb()) & 0xFFFFFF).ToString("X8"));
-                            // This encodes blue and white properly.
-                            // cyan -> white
-                            // orange -> fragmenting, breaks stuff
-                            // green -> white
-                            // red -> crashes
-                            // magenta -> crashes
-
-                            // seems like the red might be a problem. maybe this is an issue with what GetColor() returns?
-                            // maybe the binary or returns something unusual there?
-
-                            if (((bmp.GetPixel(width + dw, height).ToArgb() & GetColor(plane) ) & 0xFFFFFF) > 0)
+                            // If the pixel's color contains any of that plane's specific color (BRG), it is part of the plane data.
+                            if (((bmp.GetPixel(width + dw, height).ToArgb() & GetIdealColor(plane) ) & 0xFFFFFF) > 0)
                             {
                                 data |= 1 << (7 - dw);                    // append a binary 1; bitshift it into the correct position (high for left, low for right)
                             }
@@ -609,22 +598,35 @@ namespace CompileTools
             {
                 if (plane == 0)
                     // Values are used in FromArgb / ToArgb.
-                    // cyan-ish
+                    // darker cyan
                     return (int)0xFF0066FF;
                 if (plane == 1)
-                    // orange-red-ish
+                    // burnt orange
                     return (int)0xFFFF6600;
                 if (plane == 2)
-                    // lime-green
+                    // lime green
                     return (int)0xFF00FF00;
                 return (int)0xFFFFFFFF;
+            }
+        }
 
-                //
-                // cyan + orange = light pink (0xffccff)
-                // cyan + lime =   light cyan (0x00ffff)
-                // orange + lime =     yellow (0xffff00)
-                // all =                white (0xffffff)
-                // none =               black (0x000000)
+        public int GetIdealColor(int plane)
+            // Returns the ARGB integer the plane would have if the game used pure red, blue, green.
+            // Used in bmp -> gdt.
+        {
+            unchecked
+            {
+                if (plane == 0)
+                    // Values are used in FromArgb / ToArgb.
+                    // blue
+                    return (int)0xFF0000FF;
+                if (plane == 1)
+                    // red
+                    return (int)0xFFFF0000;
+                if (plane == 2)
+                    // green
+                    return (int)0xFF00FF00;
+                return (int)0xFFFFFFFF;
             }
         }
 

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -49,7 +49,6 @@ namespace CompileTools
                     {
                         if (bmp.GetPixel(width + dw, height).ToArgb() != Color.Black.ToArgb())
                         {
-                            Console.WriteLine("the block isn't totally blank");
                             allBlack = false;
                         }
                     }
@@ -57,7 +56,6 @@ namespace CompileTools
                 if (allBlack)
                 {
                     // Write a blank block, then move to the next block
-                    Console.WriteLine("it's all black");
                     output.WriteByte(0x00);
                     output.WriteByte(0x00);
                     output.WriteByte(0x00);
@@ -66,8 +64,7 @@ namespace CompileTools
 
                 for (int plane = 0; plane < 3; plane++)                               // for each plane (B R G):
                 {
-                    // When the plane's encoding method is determined, write its characteristic byte and update this string.
-                    String encodingMethod = null;
+                    List<int> planeData = new List<int>();
                     // (For now, RLE is the only one I'm even thinking about.)
                     // Next step: keep count of how many times the same "data" occurs. 
                     // When data is something different, write data * number of times, then start a new combo.
@@ -91,19 +88,21 @@ namespace CompileTools
                                 data |= 1 << (7 - dw);
                             }
                         }
-                            if (encodingMethod == null)
-                            {
-                                encodingMethod = "RLE";
-                                output.WriteByte(0x04);
-                            }
-                            //Console.WriteLine((int)data);
-                            output.WriteByte((byte)data);
-                            if (data >> 4 == (data & 0xF))            // if higher nibble equals lower nibble
-                            {
-                                // 
-                                //Console.WriteLine("writing an 01 as well");
-                                output.WriteByte(0x01);
-                            }
+
+                        planeData.Add(data);
+
+                        // If higher nibble equals lower nibble, add a 0x01.
+                        // (Because the run length of each one is 0x01??? Why not just increment runlength?)
+                        if (data >> 4 == (data & 0xF))
+                        {
+                            planeData.Add(0x01);
+                        }
+                    }
+                    output.WriteByte(0x04);
+                    foreach (int d in planeData)
+                    {
+                        // Next step: check if planeData is the same thing as the previous plane.
+                        output.WriteByte((byte)d);
                     }
                 }
             }

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -35,6 +35,9 @@ namespace CompileTools
 
             // Current encoding functionality: Uses 0x04 (RLE) flag, that's it.
             // Next step: Investigate how to implement 0x10 (repeat prevoius plane).
+            
+            // TODO: see if the smearing problems get better by trying really hard to avoid collisions with preexisting flags.
+
 
             // Input handled correctly:
             // GAMEOVER.GDT
@@ -160,6 +163,7 @@ namespace CompileTools
                             }
                             else
                             {
+                                Console.WriteLine("runLength of " + runLengthData + " is " + runLength.ToString("X2"));
                                 // run length of 4 has its own prefix control code, due to collision with 0x04 plane definer.
                                 if (runLength == 4)
                                 {
@@ -167,6 +171,14 @@ namespace CompileTools
                                     planeRLE.Add(0x84);
                                     planeRLE.Add(runLengthData);
                                 }
+
+                                //else if ((runLength == 6) || (runLength == 8))
+                                //{
+                                //    for (int i = 0; i < runLength; i++)
+                                //    {
+                                //        planeRLE.Add(runLengthData);
+                                //    }
+                                //}
                                 else
                                 {
                                     // 0x04 only does run-length encoding on data with equal nibbles!! (often 0x00 or 0xFF)
@@ -189,6 +201,7 @@ namespace CompileTools
                         }
                     }
                     // Add the last run as well, which is not caught in the above loop.
+                    Console.WriteLine("final runLength of " + runLengthData + " is " + runLength);
                     planeRLE.Add(runLengthData);
                     planeRLE.Add(runLength);
 

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -196,20 +196,26 @@ namespace CompileTools
                     }
                     else
                     {
-                        if (diffWithPreviousPlane == 0)
+                        //if (diffWithPreviousPlane == 0)
+                        //{
+                        //   // seems to be no restriction on how many 0x10s in a row.
+                        //    // But it gives me that lovely cyan instead of the white it should be... why?
+                        //    output.WriteByte(0x10);
+                        //    Console.WriteLine("repeat plane - 0x10");
+                        //}
+                        //else { 
+                        //    Console.WriteLine("writing RLE");
+                        //    output.WriteByte(0x04);
+                        //    foreach (int d in planeRLE)
+                        //   {
+                        //        output.WriteByte((byte)d);
+                        //}
+                        //}
+                        Console.WriteLine("writing RLE");
+                        output.WriteByte(0x04);
+                        foreach (int d in planeRLE)
                         {
-                            // seems to be no restriction on how many 0x10s in a row.
-                            // But it gives me that lovely cyan instead of the white it should be... why?
-                            output.WriteByte(0x10);
-                            Console.WriteLine("repeat plane - 0x10");
-                        }
-                        else { 
-                            Console.WriteLine("writing RLE");
-                            output.WriteByte(0x04);
-                            foreach (int d in planeRLE)
-                            {
-                                output.WriteByte((byte)d);
-                        }
+                            output.WriteByte((byte)d);
                         }
                     }
                 }

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -87,19 +87,23 @@ namespace CompileTools
                     {
                         int data = 0;
                         for (int dw = 0; dw < 8; dw++)                                // dw = difference in width; column in the block
+
                         {
                             // TODO: Looks like the planes are not just BRG, but comething like cyan-orange-lime...
-                            if (bmp.GetPixel(width + dw, height).B > 0 && plane == 0)
+                            //Console.WriteLine(((bmp.GetPixel(width + dw, height).ToArgb()) & 0xFFFFFF).ToString("X8"));
+                            // This encodes blue and white properly.
+                            // cyan -> white
+                            // orange -> fragmenting, breaks stuff
+                            // green -> white
+                            // red -> crashes
+                            // magenta -> crashes
+
+                            // seems like the red might be a problem. maybe this is an issue with what GetColor() returns?
+                            // maybe the binary or returns something unusual there?
+
+                            if (((bmp.GetPixel(width + dw, height).ToArgb() & GetColor(plane) ) & 0xFFFFFF) > 0)
                             {
                                 data |= 1 << (7 - dw);                    // append a binary 1; bitshift it into the correct position (high for left, low for right)
-                            }
-                            if (bmp.GetPixel(width + dw, height).R > 0 && plane == 1)
-                            {
-                                data |= 1 << (7 - dw);
-                            }
-                            if (bmp.GetPixel(width + dw, height).G > 0 && plane == 2)
-                            {
-                                data |= 1 << (7 - dw);
                             }
                         }
 
@@ -615,6 +619,7 @@ namespace CompileTools
                     return (int)0xFF00FF00;
                 return (int)0xFFFFFFFF;
 
+                //
                 // cyan + orange = light pink (0xffccff)
                 // cyan + lime =   light cyan (0x00ffff)
                 // orange + lime =     yellow (0xffff00)

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -164,11 +164,8 @@ namespace CompileTools
                         //Console.WriteLine(String.Join(", ", planeRLE));
                     }
                     // Add the last run as well, which is not caught in the above loop.
-                    if (runLength > 0)
-                    {
-                        planeRLE.Add(runLengthData);
-                        planeRLE.Add(runLength);
-                    }
+                    planeRLE.Add(runLengthData);
+                    planeRLE.Add(runLength);
 
                     // See if 0x10 (repeat previous plane) is a good option.
                     int diffWithPreviousPlane = 0;
@@ -199,20 +196,21 @@ namespace CompileTools
                     }
                     else
                     {
-                        //if (planeData.SequenceEqual(planes[currentPlane - 1]))
-                        //{
-                        //    Console.WriteLine("they're the same!");
-                        //    output.WriteByte(0x10);
-                       // }
-                        //else
-                        //{
-                        Console.WriteLine("writing RLE");
-                        output.WriteByte(0x04);
-                        foreach (int d in planeRLE)
+                        if (diffWithPreviousPlane == 0)
                         {
-                            output.WriteByte((byte)d);
+                            // seems to be no restriction on how many 0x10s in a row.
+                            // But it gives me that lovely cyan instead of the white it should be... why?
+                            output.WriteByte(0x10);
+                            Console.WriteLine("repeat plane - 0x10");
                         }
-                        //}
+                        else { 
+                            Console.WriteLine("writing RLE");
+                            output.WriteByte(0x04);
+                            foreach (int d in planeRLE)
+                            {
+                                output.WriteByte((byte)d);
+                        }
+                        }
                     }
                 }
             }

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -32,6 +32,19 @@ namespace CompileTools
         }
         public override void ConvertTo(Stream input, Stream output)
         {
+
+            // Things handled correctly:
+            // GAMEOVER.GDT (scanlined)
+            // big-text portion of TITLE1.GDT (scanlined)
+            // text from EVO chapter 1 title screen, non-scanlined
+            // above, with blocks of all colors, pure and plane versions
+
+            // Things not handled correctly:
+            // small-text portion of TITLE1.GDT (scanlined)
+            // game title screen (scanlined) (outputs 1kb file??)
+            //  - header is written correcctly, but no data...
+            // TITLE1.GDT full, scanlined and otherwise
+
             Bitmap bmp = new Bitmap(Bitmap.FromStream(input));
             WriteInt16(output, unchecked((short)0xE488));
             WriteInt32(output, 0);

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ CompileTools is a romhacking program being developed mainly by M-bot, blacksmith
 ### Examples
 ```
  convert file.gmp       -> file.bmp
+ convert file.bmp gdt   -> file.gdt
  compress file.cnx      -> file.gmp
  compress file.gmp      -> file.cnx
  pack file.it3          -> file.it3_index + file (directory)


### PR DESCRIPTION
Makes use of the run-length plane encoding flag 0x04, and encodes colors mostly correctly. Properly re-encodes GAMEOVER.GDT, MAP100.GDT, and other small images; title cards need to be cropped a bit in order to work properly.