### PR TITLE
Add plane-copying modes to BMP->GDT encoder

### DIFF
--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -33,17 +33,18 @@ namespace CompileTools
         public override void ConvertTo(Stream input, Stream output)
         {
 
-            // Things handled correctly:
-            // GAMEOVER.GDT (scanlined)
-            // big-text portion of TITLE1.GDT (scanlined)
-            // text from EVO chapter 1 title screen, non-scanlined
-            // above, with blocks of all colors, pure and plane versions
+            // Input handled correctly:
+            // GAMEOVER.GDT
+            // MAP100.GDT (and likely other maps as well, but not tested)
+            // all title cards when cropped (remove bottom and right sides; they're only black anyway)
+            // EVO (SNES) chapter title 1
+            // above images with 16-bit color blocks pasted haphazardly
 
-            // Things not handled correctly:
-            // small-text portion of TITLE1.GDT (scanlined)
-            // game title screen (scanlined) (outputs 1kb file??)
-            //  - header is written correcctly, but no data...
-            // TITLE1.GDT full, scanlined and otherwise
+            // Inputs handled incorrectly:
+            // unedited title card images - smearing occurs
+            // game title screen (AV04B.GDT) - smearing occurs
+            // EVO chapter 1 title screen, doubled in size (but still 640x400 px) - smearing occurs
+            // 50% of scanlined images become blank if it's misaligned (you can shift the image up/down to fix this)
 
             Bitmap bmp = new Bitmap(Bitmap.FromStream(input));
             WriteInt16(output, unchecked((short)0xE488));
@@ -238,6 +239,13 @@ namespace CompileTools
                         }
                     }
                 }
+            }
+
+            if (output.Length == 11)
+            {
+                // It's probably misreading a scanliend image.
+                Console.WriteLine("Warning: Looks like the output image is blank.");
+                Console.WriteLine("If the input image has scanlines, try shifting it up or down a line.");
             }
         }
 

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -131,6 +131,22 @@ namespace CompileTools
                         planeData.Add(data);
                     }
 
+                    // if it's all zeros, just write 0x00 and call it a day
+                    //for (var i=0; i<planeData.Count; i++)
+                    //{
+                     //   Console.Write("{0:X2} ", (int)planeData[i]);
+                    //}
+                    //Console.WriteLine("");
+                    if (planeData.Sum() == 0)
+                    {
+                        Console.WriteLine("Best to just encode 0x00");
+                        output.WriteByte((byte)0x00);
+
+                        planes.Add(planeData);
+                        planesCopied.Add(false);
+                        continue;
+                    }
+
                     // Now, we can compare this data to previous planes and see if we can just copy it.
                     // You can copy the previous plane (0x10? 0x14?) or the same color plane in the nth previous block (0x80?)
                     // Use a Hamming distance function. If it's small, you can probably use one of the plane copiers to grab that plane
@@ -169,7 +185,7 @@ namespace CompileTools
                         bestPlaneDistance = distances.Min();
                         bestPlaneIndex = startPlane + distances.IndexOf(bestPlaneDistance);
 
-                        Console.WriteLine("Best plane to copy would be {0}, which has distance {1}", bestPlaneIndex, bestPlaneDistance);
+                        //Console.WriteLine("Best plane to copy would be {0}, which has distance {1}", bestPlaneIndex, bestPlaneDistance);
                     }
 
                     planes.Add(planeData);

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -65,7 +65,10 @@ namespace CompileTools
                     prevPlaneData.Clear();
                     continue;
                 }
-                
+
+                List<List<int>> planes = new List<List<int>>();
+                // TODO: Store planes. Use comparative or to see whether positional encoding might be more efficient.
+
 
                 for (int plane = 0; plane < 3; plane++)                               // for each plane (B R G):
                 {

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -96,45 +96,43 @@ namespace CompileTools
                             }
                         }
 
-                        if (data > 0)
-                        {
-                            planeData.Add((byte)(height/2));
-                            Console.WriteLine(height / 2);
-                            planeData.Add((byte)data);
-                        }
+                        //if (data > 0)
+                        //{
+                        //    planeData.Add((byte)(height/2));
+                        //    Console.WriteLine(height / 2);
+                        //    planeData.Add((byte)data);
+                        //}
 
                         //if (data == runLengthData)
                         //{
-                         //   runLength++;
+                        //    runLength++;
                         //}
                         //else
                         //{
-
+                        //
                         //    planeData.Add((byte)runLengthData);
                         //    planeData.Add((byte)runLength);
-
-                         //   runLengthData = data;
+                        //
+                        //    runLengthData = data;
                         //    runLength = 1;
                         //}
 
-                        //planeData.Add(data);
+                        planeData.Add(data);
 
                         // If higher nibble equals lower nibble, add a 0x01.
                         // (Because the run length of each one is 0x01??? Why not just increment runlength?)
-                        //if (data >> 4 == (data & 0xF))
-                        //{
-                        //    planeData.Add(0x01);
-                        //}
+                        if (data >> 4 == (data & 0xF))
+                        {
+                            planeData.Add(0x01);
+                        }
                     }
                     //if (runLength > 1)
                     //{
                     //    planeData.Add((byte)runLengthData);
                     //    planeData.Add((byte)runLength);
-                   // }
+                    // }
 
-                    //output.WriteByte(0x04);
-
-                    if (planeData == prevPlaneData)
+                    if (planeData.SequenceEqual(prevPlaneData))
                     {
                         Console.WriteLine("they're the same!");
                         output.WriteByte(0x10);
@@ -142,15 +140,17 @@ namespace CompileTools
                     else
                     {
                         // 0x81 = begin POS
-                        output.WriteByte(0x81);
+                        //output.WriteByte(0x81);
+
+                        //0x04 = begin RLE
+                        output.WriteByte(0x04);
                         foreach (int d in planeData)
                         {
-                            // Next step: check if planeData is the same thing as the previous plane.
                             output.WriteByte((byte)d);
                         }
                         // 0xFF 0xFF = end POS
-                        output.WriteByte(0xFF);
-                        output.WriteByte(0xFF);
+                        //output.WriteByte(0xFF);
+                        //output.WriteByte(0xFF);
                     }
                     prevPlaneData = planeData;
                 }

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -132,11 +132,6 @@ namespace CompileTools
                     }
 
                     // if it's all zeros, just write 0x00 and call it a day
-                    //for (var i=0; i<planeData.Count; i++)
-                    //{
-                    //   Console.Write("{0:X2} ", (int)planeData[i]);
-                    //}
-                    //Console.WriteLine("");
 
                     if (planeData.Sum() == 0)
                     {
@@ -253,7 +248,7 @@ namespace CompileTools
                                         {
                                             // Can't have a C byte in the upper byte of the run length.
                                             // (Haven't really checked this yet.)
-                                            byte lengthUpper = (byte)(runLength >> 4);
+                                            //byte lengthUpper = (byte)(runLength >> 4);
                                             //if (lengthUpper == (byte)0xC)
                                             //{
                                             //    Console.WriteLine("It's a C byte!");
@@ -342,6 +337,11 @@ namespace CompileTools
                         }
                     }
                 }
+            }
+
+            for (var i=0; i<planesCopied.Count; i++)
+            {
+                Console.Write("{0}: {1} ", i, planesCopied[i]);
             }
 
             if (output.Length == 11)

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -89,19 +89,8 @@ namespace CompileTools
                         for (int dw = 0; dw < 8; dw++)                                // dw = difference in width; column in the block
 
                         {
-                            // TODO: Looks like the planes are not just BRG, but comething like cyan-orange-lime...
-                            //Console.WriteLine(((bmp.GetPixel(width + dw, height).ToArgb()) & 0xFFFFFF).ToString("X8"));
-                            // This encodes blue and white properly.
-                            // cyan -> white
-                            // orange -> fragmenting, breaks stuff
-                            // green -> white
-                            // red -> crashes
-                            // magenta -> crashes
-
-                            // seems like the red might be a problem. maybe this is an issue with what GetColor() returns?
-                            // maybe the binary or returns something unusual there?
-
-                            if (((bmp.GetPixel(width + dw, height).ToArgb() & GetColor(plane) ) & 0xFFFFFF) > 0)
+                            // If the pixel's color contains any of that plane's specific color (BRG), it is part of the plane data.
+                            if (((bmp.GetPixel(width + dw, height).ToArgb() & GetIdealColor(plane) ) & 0xFFFFFF) > 0)
                             {
                                 data |= 1 << (7 - dw);                    // append a binary 1; bitshift it into the correct position (high for left, low for right)
                             }
@@ -609,22 +598,35 @@ namespace CompileTools
             {
                 if (plane == 0)
                     // Values are used in FromArgb / ToArgb.
-                    // cyan-ish
+                    // darker cyan
                     return (int)0xFF0066FF;
                 if (plane == 1)
-                    // orange-red-ish
+                    // burnt orange
                     return (int)0xFFFF6600;
                 if (plane == 2)
-                    // lime-green
+                    // lime green
                     return (int)0xFF00FF00;
                 return (int)0xFFFFFFFF;
+            }
+        }
 
-                //
-                // cyan + orange = light pink (0xffccff)
-                // cyan + lime =   light cyan (0x00ffff)
-                // orange + lime =     yellow (0xffff00)
-                // all =                white (0xffffff)
-                // none =               black (0x000000)
+        public int GetIdealColor(int plane)
+            // Returns the ARGB integer the plane would have if the game used pure red, blue, green.
+            // Used in bmp -> gdt.
+        {
+            unchecked
+            {
+                if (plane == 0)
+                    // Values are used in FromArgb / ToArgb.
+                    // blue
+                    return (int)0xFF0000FF;
+                if (plane == 1)
+                    // red
+                    return (int)0xFFFF0000;
+                if (plane == 2)
+                    // green
+                    return (int)0xFF00FF00;
+                return (int)0xFFFFFFFF;
             }
         }
 

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -314,7 +314,15 @@ namespace CompileTools
                         // Add the last run as well, which is not caught in the above loop.
                         Console.WriteLine("");
                         planeRLE.Add(runLengthData);
-                        planeRLE.Add(runLength);
+                        if (runLength > 0x7D)
+                        {
+                            planeRLE.Add(0x7e);
+                            planeRLE.Add(runLength);
+                        }
+                        else
+                        {
+                            planeRLE.Add(runLength);
+                        }
                         Console.Write("{0:X2} {1:X2} ", runLengthData, runLength);
                         row += runLength;
                         Console.WriteLine("length: {0}", row);

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -49,7 +49,6 @@ namespace CompileTools
                     {
                         if (bmp.GetPixel(width + dw, height).ToArgb() != Color.Black.ToArgb())
                         {
-                            Console.WriteLine("the block isn't totally blank");
                             allBlack = false;
                         }
                     }
@@ -57,7 +56,6 @@ namespace CompileTools
                 if (allBlack)
                 {
                     // Write a blank block, then move to the next block
-                    Console.WriteLine("it's all black");
                     output.WriteByte(0x00);
                     output.WriteByte(0x00);
                     output.WriteByte(0x00);
@@ -66,8 +64,7 @@ namespace CompileTools
 
                 for (int plane = 0; plane < 3; plane++)                               // for each plane (B R G):
                 {
-                    // When the plane's encoding method is determined, write its characteristic byte and update this string.
-                    String encodingMethod = null;
+                    List<int> planeData = new List<int>();
                     // (For now, RLE is the only one I'm even thinking about.)
                     // Next step: keep count of how many times the same "data" occurs. 
                     // When data is something different, write data * number of times, then start a new combo.
@@ -91,19 +88,21 @@ namespace CompileTools
                                 data |= 1 << (7 - dw);
                             }
                         }
-                            if (encodingMethod == null)
-                            {
-                                encodingMethod = "RLE";
-                                output.WriteByte(0x04);
-                            }
-                            //Console.WriteLine((int)data);
-                            output.WriteByte((byte)data);
-                            if (data >> 4 == (data & 0xF))            // if higher nibble equals lower nibble
-                            {
-                                // 
-                                //Console.WriteLine("writing an 01 as well");
-                                output.WriteByte(0x01);
-                            }
+
+                        planeData.Add(data);
+
+                        // If higher nibble equals lower nibble, add a 0x01.
+                        // (Because the run length of each one is 0x01??? Why not just increment runlength?)
+                        if (data >> 4 == (data & 0xF))
+                        {
+                            planeData.Add(0x01);
+                        }
+                    }
+                    output.WriteByte(0x04);
+                    foreach (int d in planeData)
+                    {
+                        // Next step: check if planeData is the same thing as the previous plane.
+                        output.WriteByte((byte)d);
                     }
                 }
             }

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -35,6 +35,9 @@ namespace CompileTools
 
             // Current encoding functionality: Uses 0x04 (RLE) flag, that's it.
             // Next step: Investigate how to implement 0x10 (repeat prevoius plane).
+            
+            // TODO: see if the smearing problems get better by trying really hard to avoid collisions with preexisting flags.
+
 
             // Input handled correctly:
             // GAMEOVER.GDT
@@ -160,6 +163,7 @@ namespace CompileTools
                             }
                             else
                             {
+                                Console.WriteLine("runLength of " + runLengthData + " is " + runLength.ToString("X2"));
                                 // run length of 4 has its own prefix control code, due to collision with 0x04 plane definer.
                                 if (runLength == 4)
                                 {
@@ -167,6 +171,14 @@ namespace CompileTools
                                     planeRLE.Add(0x84);
                                     planeRLE.Add(runLengthData);
                                 }
+
+                                //else if ((runLength == 6) || (runLength == 8))
+                                //{
+                                //    for (int i = 0; i < runLength; i++)
+                                //    {
+                                //        planeRLE.Add(runLengthData);
+                                //    }
+                                //}
                                 else
                                 {
                                     // 0x04 only does run-length encoding on data with equal nibbles!! (often 0x00 or 0xFF)
@@ -189,6 +201,7 @@ namespace CompileTools
                         }
                     }
                     // Add the last run as well, which is not caught in the above loop.
+                    Console.WriteLine("final runLength of " + runLengthData + " is " + runLength);
                     planeRLE.Add(runLengthData);
                     planeRLE.Add(runLength);
 

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -196,20 +196,26 @@ namespace CompileTools
                     }
                     else
                     {
-                        if (diffWithPreviousPlane == 0)
+                        //if (diffWithPreviousPlane == 0)
+                        //{
+                        //   // seems to be no restriction on how many 0x10s in a row.
+                        //    // But it gives me that lovely cyan instead of the white it should be... why?
+                        //    output.WriteByte(0x10);
+                        //    Console.WriteLine("repeat plane - 0x10");
+                        //}
+                        //else { 
+                        //    Console.WriteLine("writing RLE");
+                        //    output.WriteByte(0x04);
+                        //    foreach (int d in planeRLE)
+                        //   {
+                        //        output.WriteByte((byte)d);
+                        //}
+                        //}
+                        Console.WriteLine("writing RLE");
+                        output.WriteByte(0x04);
+                        foreach (int d in planeRLE)
                         {
-                            // seems to be no restriction on how many 0x10s in a row.
-                            // But it gives me that lovely cyan instead of the white it should be... why?
-                            output.WriteByte(0x10);
-                            Console.WriteLine("repeat plane - 0x10");
-                        }
-                        else { 
-                            Console.WriteLine("writing RLE");
-                            output.WriteByte(0x04);
-                            foreach (int d in planeRLE)
-                            {
-                                output.WriteByte((byte)d);
-                        }
+                            output.WriteByte((byte)d);
                         }
                     }
                 }

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -87,19 +87,23 @@ namespace CompileTools
                     {
                         int data = 0;
                         for (int dw = 0; dw < 8; dw++)                                // dw = difference in width; column in the block
+
                         {
                             // TODO: Looks like the planes are not just BRG, but comething like cyan-orange-lime...
-                            if (bmp.GetPixel(width + dw, height).B > 0 && plane == 0)
+                            //Console.WriteLine(((bmp.GetPixel(width + dw, height).ToArgb()) & 0xFFFFFF).ToString("X8"));
+                            // This encodes blue and white properly.
+                            // cyan -> white
+                            // orange -> fragmenting, breaks stuff
+                            // green -> white
+                            // red -> crashes
+                            // magenta -> crashes
+
+                            // seems like the red might be a problem. maybe this is an issue with what GetColor() returns?
+                            // maybe the binary or returns something unusual there?
+
+                            if (((bmp.GetPixel(width + dw, height).ToArgb() & GetColor(plane) ) & 0xFFFFFF) > 0)
                             {
                                 data |= 1 << (7 - dw);                    // append a binary 1; bitshift it into the correct position (high for left, low for right)
-                            }
-                            if (bmp.GetPixel(width + dw, height).R > 0 && plane == 1)
-                            {
-                                data |= 1 << (7 - dw);
-                            }
-                            if (bmp.GetPixel(width + dw, height).G > 0 && plane == 2)
-                            {
-                                data |= 1 << (7 - dw);
                             }
                         }
 
@@ -615,6 +619,7 @@ namespace CompileTools
                     return (int)0xFF00FF00;
                 return (int)0xFFFFFFFF;
 
+                //
                 // cyan + orange = light pink (0xffccff)
                 // cyan + lime =   light cyan (0x00ffff)
                 // orange + lime =     yellow (0xffff00)

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -164,11 +164,8 @@ namespace CompileTools
                         //Console.WriteLine(String.Join(", ", planeRLE));
                     }
                     // Add the last run as well, which is not caught in the above loop.
-                    if (runLength > 0)
-                    {
-                        planeRLE.Add(runLengthData);
-                        planeRLE.Add(runLength);
-                    }
+                    planeRLE.Add(runLengthData);
+                    planeRLE.Add(runLength);
 
                     // See if 0x10 (repeat previous plane) is a good option.
                     int diffWithPreviousPlane = 0;
@@ -199,20 +196,21 @@ namespace CompileTools
                     }
                     else
                     {
-                        //if (planeData.SequenceEqual(planes[currentPlane - 1]))
-                        //{
-                        //    Console.WriteLine("they're the same!");
-                        //    output.WriteByte(0x10);
-                       // }
-                        //else
-                        //{
-                        Console.WriteLine("writing RLE");
-                        output.WriteByte(0x04);
-                        foreach (int d in planeRLE)
+                        if (diffWithPreviousPlane == 0)
                         {
-                            output.WriteByte((byte)d);
+                            // seems to be no restriction on how many 0x10s in a row.
+                            // But it gives me that lovely cyan instead of the white it should be... why?
+                            output.WriteByte(0x10);
+                            Console.WriteLine("repeat plane - 0x10");
                         }
-                        //}
+                        else { 
+                            Console.WriteLine("writing RLE");
+                            output.WriteByte(0x04);
+                            foreach (int d in planeRLE)
+                            {
+                                output.WriteByte((byte)d);
+                        }
+                        }
                     }
                 }
             }

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -32,6 +32,19 @@ namespace CompileTools
         }
         public override void ConvertTo(Stream input, Stream output)
         {
+
+            // Things handled correctly:
+            // GAMEOVER.GDT (scanlined)
+            // big-text portion of TITLE1.GDT (scanlined)
+            // text from EVO chapter 1 title screen, non-scanlined
+            // above, with blocks of all colors, pure and plane versions
+
+            // Things not handled correctly:
+            // small-text portion of TITLE1.GDT (scanlined)
+            // game title screen (scanlined) (outputs 1kb file??)
+            //  - header is written correcctly, but no data...
+            // TITLE1.GDT full, scanlined and otherwise
+
             Bitmap bmp = new Bitmap(Bitmap.FromStream(input));
             WriteInt16(output, unchecked((short)0xE488));
             WriteInt32(output, 0);

--- a/CompileTools/GDT.cs
+++ b/CompileTools/GDT.cs
@@ -32,6 +32,7 @@ namespace CompileTools
         }
         public override void ConvertTo(Stream input, Stream output)
         {
+
             // Current encoding functionality: Uses 0x04 (RLE) flag, 0x10 (repeat previous plane), 0x8N (copy nth previous block's analogous plane).
 
             // Things you can do to make images insert a little better:
@@ -43,11 +44,10 @@ namespace CompileTools
             WriteInt16(output, unchecked((short)0xE488));
             WriteInt32(output, 0);
             WriteInt16(output, (short)bmp.Width);
-            WriteInt16(output, (short)(bmp.Height/2));
+            WriteInt16(output, (short)(bmp.Height / 2));
             output.WriteByte(0x11);
 
             List<List<int>> planes = new List<List<int>>();
-
             List<Boolean> planesCopied = new List<Boolean>();
             int currentPlane = 0;
 
@@ -55,7 +55,7 @@ namespace CompileTools
             List<int> blankPlane = new List<int>(Enumerable.Repeat(0x00, bmp.Height / 2));
 
             // Look at the input bmp and consider it in 8-pixel-wide blocks:
-            for (int width = 0; width < (bmp.Width - 8); width+=8)
+            for (int width = 0; width < (bmp.Width - 8); width += 8)
             {
                 // First, check if the block is entirely black. If so, we can write "00-00-00" and skip it.
                 bool allBlack = true;
@@ -84,7 +84,6 @@ namespace CompileTools
                     planesCopied.Add(false);
                     planesCopied.Add(false);
                     planesCopied.Add(false);
-                    
                     currentPlane += 3;
 
                     continue;
@@ -98,9 +97,9 @@ namespace CompileTools
                     List<int> planeData = new List<int>();
 
                     //currentPlane++;
-                    Console.WriteLine("Processing plane {0}. {1} plane at {2}", currentPlane, currentPlane % 3, (currentPlane / 3)*8);
+                    Console.WriteLine("Processing plane {0}. {1} plane at {2}", currentPlane, currentPlane % 3, (currentPlane / 3) * 8);
 
-                    for (int height = 0; height < bmp.Height; height+=2)
+                    for (int height = 0; height < bmp.Height; height += 2)
                     {
                         int data = 0;
                         for (int dw = 0; dw < 8; dw++)                                // dw = difference in width; column in the block
@@ -113,17 +112,17 @@ namespace CompileTools
                             // #00FF00 G  -> #00FF00 (same green)
 
                             if ((bmp.GetPixel(width + dw, height).B > 0) && plane == 0)
-                                // If there's any blue at all, add the data to the blue plane
+                            // If there's any blue at all, add the data to the blue plane
                             {
                                 data |= 1 << (7 - dw);
                             }
                             if ((bmp.GetPixel(width + dw, height).R > 0) && plane == 1)
-                                // if there's any red at all, add the data to the red plane
+                            // if there's any red at all, add the data to the red plane
                             {
                                 data |= 1 << (7 - dw);
                             }
                             if ((bmp.GetPixel(width + dw, height).G > 102) && plane == 2)
-                                // If there's green, but not the mere 0x66 green mixed in the burnt orange/light blue, add it
+                            // If there's green, but not the mere 0x66 green mixed in the burnt orange/light blue, add it
                             {
                                 data |= 1 << (7 - dw);
                             }
@@ -131,7 +130,7 @@ namespace CompileTools
 
                         planeData.Add(data);
                     }
-                    
+
                     // if it's all zeros, just write 0x00 and call it a day
 
                     if (planeData.Sum() == 0)
@@ -194,9 +193,10 @@ namespace CompileTools
                         output.WriteByte((byte)0x10);
                         planesCopied.Add(true);
                     }
-                    
+
                     // if it's the same plane in a different block, and its diff is 0...
-                    else if (bestPlaneDiff % 3 == 0 && bestPlaneDistance == 0) {
+                    else if (bestPlaneDiff % 3 == 0 && bestPlaneDistance == 0)
+                    {
                         Console.WriteLine("Copying plane {0}", bestPlaneIndex);
                         // From the decoder:
                         // CopyData(block - datab - 1, block, plane, plane);
@@ -271,7 +271,7 @@ namespace CompileTools
                                             //        planeRLE.Add(runLength / 2);
                                             //        row += runLength;
                                             //    }
-                                           // }
+                                            // }
                                             // Length can only go up to 7D; otherwise you need a 7E byte in front.
                                             if (runLength > 0x7D)
                                             {
@@ -325,9 +325,9 @@ namespace CompileTools
 
                         // Finally, write the data to the output stream.
                         Console.WriteLine("writing RLE");
-                        for (var i=0; i<planeRLE.Count; i++)
+                        for (var i = 0; i < planeRLE.Count; i++)
                         {
-                           Console.Write("{0:X2} ", (int)planeRLE[i]);
+                            Console.Write("{0:X2} ", (int)planeRLE[i]);
                         }
                         Console.WriteLine("");
 
@@ -337,24 +337,10 @@ namespace CompileTools
                             output.WriteByte((byte)d);
                         }
                     }
-                    // Add the last run as well, which is not caught in the above loop.
-                    Console.WriteLine("final runLength of " + runLengthData + " is " + runLength);
-                    planeRLE.Add(runLengthData);
-                    planeRLE.Add(runLength);
-
-                    // Finally, write the data to the output stream.
-                    Console.WriteLine("writing RLE");
-                    output.WriteByte(0x04);
-                    foreach (int d in planeRLE)
-                    {
-                        output.WriteByte((byte)d);
-                    }
-
                 }
             }
 
-
-            for (var i=0; i<planesCopied.Count; i++)
+            for (var i = 0; i < planesCopied.Count; i++)
             {
                 Console.Write("{0}: {1} ", i, planesCopied[i]);
             }
@@ -373,27 +359,27 @@ namespace CompileTools
         {
             // Discarding 6 bytes that appears to always start with 0x88 0xE4
             // They probably provide information but this program doesn't know how to deal with them
-            ReadInt16(input);                           
-            ReadInt16(input);                           
-            ReadInt16(input);                           
+            ReadInt16(input);
+            ReadInt16(input);
+            ReadInt16(input);
 
             // Reading the width and height, which is then followed by the end of the "header"
             // The last byte appears to always be 0x11
-            int width = ReadInt16(input);               
-            height = ReadInt16(input);                  
-            input.ReadByte();                           
+            int width = ReadInt16(input);
+            height = ReadInt16(input);
+            input.ReadByte();
 
             // The format encodes the image in a series of blocks that are 8 pixels wide and image height tall.
             // Each block is seperated into three color planes that hold various instructions on what to draw.
             // We initialize the buffer we will be writing to as three dimensional array of integers. 
             // Each integer represents an 8 pixel draw line at a certain height within a block's color plane.
-            int numberOfBlocks = width / 8;             
+            int numberOfBlocks = width / 8;
             pixels = new int[numberOfBlocks, 3, height];
 
-            
+
             // This is the buffer that will be used to save the file once we are done decoding
             Bitmap bmp = new Bitmap(width, height * 2, PixelFormat.Format32bppRgb);
-            
+
             // A try finally is used to make sure we always dump the last image created into the file
             // This is done since we don't know how to entirely decode the image at times and the 
             // program will fail. Dumping the last image allows us to see the progress it made.
@@ -407,17 +393,17 @@ namespace CompileTools
                     for (int plane = 0; plane < 3; plane++)
                     {
                         indexOfPrevPlane = input.Position;
-                        
+
                         // Reads the encoding flag and splits it into nibbles
                         int data = input.ReadByte();
                         int datat = data >> 4;
                         int datab = data & 0x0F;
-                        
+
                         // Since the each plane is not a continous set of a data  we have to keep track
                         // of the currrent line so we can write data in the correct area as well as keep
                         // within the bounds of the image
                         int curLine = 0;
-                        
+
                         // Use a boolean to notify of known errors that didn't cause the program to crash
                         bool error = false;
 
@@ -539,7 +525,7 @@ namespace CompileTools
                                         if ((count & 0xF0) == 0xC0)
                                         {
                                             count -= 0xC0;
-                                            if (data == 0xFF) 
+                                            if (data == 0xFF)
                                                 data = input.ReadByte();
                                             if (data == 0x00)
                                             {
@@ -683,7 +669,7 @@ namespace CompileTools
                                     }
 
                                     WriteData(block, plane, curLine, data, datat);
-                           end6:    curLine += datat;
+                                    end6: curLine += datat;
                                 }
                                 break;
                             default:
@@ -691,7 +677,7 @@ namespace CompileTools
                                 break;
                         }
 
-                    print: endOfPrevPlane = input.Position;
+                        print: endOfPrevPlane = input.Position;
 
                         if (error)
                             Console.ForegroundColor = ConsoleColor.Red;
@@ -772,7 +758,7 @@ namespace CompileTools
         public void WriteData(int block, int plane, int line, int data, int count)
         {
             if (wtf)
-                // wtf indeed!
+            // wtf indeed!
             {
                 // hmm. when does this apply? data should be 0xFF at its highest, right?
                 if ((data & 0xFF00) > 0)
@@ -830,7 +816,7 @@ namespace CompileTools
 
         public void CopyData(int b1, int b2, int p1, int p2)
         {
-            for(int l = 0; l < height; l++)
+            for (int l = 0; l < height; l++)
             {
                 pixels[b2, p2, l] ^= pixels[b1, p1, l];
             }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ CompileTools is a romhacking program being developed mainly by M-bot, blacksmith
 ### Examples
 ```
  convert file.gmp       -> file.bmp
+ convert file.bmp gdt   -> file.gdt
  compress file.cnx      -> file.gmp
  compress file.gmp      -> file.cnx
  pack file.it3          -> file.it3_index + file (directory)


### PR DESCRIPTION
This updates the GDT encoder to the one I used to encode the final images in the 46 Okunen Monogatari project. The images are complete and usually well within the 16KB image limit.

(This should be merged correctly now.)