### PR TITLE
Fix IT3 file extension when packing

### DIFF
--- a/CompileTools.CLI/Commands/PackCommand.cs
+++ b/CompileTools.CLI/Commands/PackCommand.cs
@@ -22,6 +22,9 @@ namespace CompileTools.CLI.Commands
 
             string method = args.Length > 1 ? "." + args[1] : ext;
             ArchiveMethod archiver = ArchiveMethod.FindArchiver(method);
+            if (method == ".it3_index")
+                method = ".it3";
+
             string outputFile = Path.GetFileNameWithoutExtension(file) + method;
 
             if (archiver == null)


### PR DESCRIPTION
When packing, you need to specify the `.it3_index` file; however, the packer uses this file extension for the resulting IT3 file.

This commit changes the output file name such that its extension is `.it3`.

```
$ CompileTools.CLI.exe pack Unpacked/c0000.it3_index
$ ls Packed
c0000.it3
```
