### PR TITLE
Fix IT3 unpack pointer increment

### DIFF
--- a/CompileTools/IT3.cs
+++ b/CompileTools/IT3.cs
@@ -58,7 +58,7 @@ namespace CompileTools
             List<FileReference> output = new List<FileReference>(); 
             int count = 0;
             FileReference index = new FileReference(new MemoryStream(), Path.GetFileNameWithoutExtension(input.FileName) + ".it3_index", "");
-            for(int pointer = 0; pointer < input.Stream.Length; pointer++,count++)
+            for(int pointer = 0; pointer < input.Stream.Length; count++)
             {
                 string fourcc = ReadString(input.Stream, 4);
                 int size = ReadInt32(input.Stream);


### PR DESCRIPTION
Certain IT3 files cannot be unpacked / re-packed correctly at the moment.

It seems like the pointer offset calculation has a bug. `pointer` is offset with the correct number of bytes in line 79. Incrementing it by one every iteration does seem unintended.